### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,7 +14,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "6750280b426ab2447467d096",
+  "nxCloudId": "67af6eb6e3fb2b6d52da89cc",
   "targetDefaults": {
     "@nx/esbuild:esbuild": {
       "cache": true,
@@ -23,17 +23,10 @@
     }
   },
   "plugins": [
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      },
+      "options": { "targetName": "test" },
       "exclude": [
         "apps/mcp-neo4j-e2e/**/*",
         "mcp-neo4j-memory-e2e/**/*",
@@ -41,13 +34,7 @@
         "servers/mcp-json-memory-e2e/**/*"
       ]
     },
-    {
-      "plugin":"@nxlv/python"
-    }
+    { "plugin": "@nxlv/python" }
   ],
-  "release": {
-    "version": {
-      "preVersionCommand": "npx nx run-many -t build"
-    }
-  }
+  "release": { "version": { "preVersionCommand": "npx nx run-many -t build" } }
 }


### PR DESCRIPTION
### **User description**
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/67a3cc7cf66963dce239a340/workspaces/67af6eb6e3fb2b6d52da89cc

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.


___

### **PR Type**
Enhancement


___

### **Description**
- Configured Nx Cloud for distributed caching and CI integration.

- Updated `nxCloudId` to a new identifier.

- Reformatted JSON structure for plugins and release configuration.

- Improved maintainability by consolidating plugin and release configurations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nx.json</strong><dd><code>Updated Nx Cloud ID and reformatted JSON structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nx.json

<li>Updated <code>nxCloudId</code> to a new identifier.<br> <li> Reformatted plugin configurations for ESLint, Jest, and Python.<br> <li> Consolidated release configuration into a single line.<br> <li> Improved JSON formatting for better readability and maintainability.


</details>


  </td>
  <td><a href="https://github.com/ArieZm/mcp-neo4j/pull/1/files#diff-15552e50b1b7c05b05b7ffe08ee47b5ed62b8d2039229c58972a42fd22a7381c">+5/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>